### PR TITLE
docs: add LLM-optimised documentation suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,172 @@
+# CLAUDE.md – Holly Codebase Guide
+
+This file gives an LLM agent orientation for working in the Holly repository.
+
+---
+
+## What Holly Does
+
+Holly is an AI-assisted software development platform. Users create **missions** (scoped coding tasks) that run inside isolated Docker containers called **Hilly**. A SvelteKit frontend talks to a Django backend; the backend provisions containers, proxies MCP tool calls, and streams progress to the browser via SSE.
+
+---
+
+## Documentation Index
+
+| Doc | What it covers |
+|---|---|
+| [`docs/overview.md`](docs/overview.md) | Architecture diagram, core concepts, tech stack, repo layout, mission lifecycle states |
+| [`docs/backend.md`](docs/backend.md) | Django apps, models (Mission, Conversation, LLM, Tools), services, API endpoints, auth, Celery tasks, settings |
+| [`docs/frontend.md`](docs/frontend.md) | SvelteKit routes, Svelte stores, API client generation, key components, build scripts |
+| [`docs/flows.md`](docs/flows.md) | Step-by-step sequence diagrams: login, GitHub OAuth, mission start SSE, chat streaming, tool execution, teardown |
+| [`docs/GH_APP_SETUP.md`](docs/GH_APP_SETUP.md) | GitHub App configuration for local development |
+
+---
+
+## Quick Orientation
+
+### Three-Tier Architecture
+
+```
+SvelteKit :5173  ──REST+SSE──▶  Django :8000  ──Docker──▶  Hilly container
+                                     │                        :8090 MCP API
+                                     │                        :8181 AI Agent
+                                     ▼
+                               Redis / RabbitMQ / Celery
+```
+
+### Key Directories
+
+```
+backend/holly/holly/          ← core Django app
+  models/mission.py           ← Mission model (states: draft→provisioning→ready→in_progress→completed)
+  models/conversations.py     ← Message model (role: user|assistant|system|tool)
+  models/llms.py              ← LLM configuration
+  api/views/mission.py        ← mission CRUD + SSE /sse/start/
+  api/views/conversations.py  ← chat endpoints + SSE stream
+  api/proxy.py                ← MCPProxyClient (Django → Hilly container)
+  services/mission_service.py ← lifecycle orchestration
+
+frontend/src/
+  routes/wizard/              ← 6-step mission creation wizard
+  routes/sse-chat/            ← real-time chat UI
+  lib/store/auth/             ← JWT token storage
+  lib/store/chat/             ← active conversation + messages
+  lib/apis/                   ← auto-generated + wrapper API clients
+
+hilly/rest_mcp_client/        ← FastAPI server inside each container (:8090)
+hilly/aiagents/               ← AI agent + MCP tools (git submodule)
+```
+
+---
+
+## Mission Lifecycle
+
+```
+DRAFT → PROVISIONING → READY → IN_PROGRESS → COMPLETED
+                                           → ABORTED
+                                           → ERROR
+```
+
+- **DRAFT**: created via wizard, no container yet
+- **PROVISIONING**: `GET /missions/{id}/sse/start/` called; Docker container spinning up
+- **READY**: container healthy, repos cloned; SSE stream closes
+- **IN_PROGRESS**: conversations happening, LLM working
+- **COMPLETED/ABORTED/ERROR**: container stopped
+
+---
+
+## Authentication
+
+- **JWT**: access token (5 min) + refresh token (7 days)
+- SSE endpoints accept `?token=<jwt>` in query string (EventSource cannot set headers)
+- GitHub OAuth via django-allauth → issues Holly JWT after callback
+- Token refresh is automatic (frontend middleware retries on 401)
+
+---
+
+## Chat & Tool Execution
+
+1. `POST /missions/{id}/conversation/` → get `conversation_id`
+2. Open `EventSource` on `/conversations/{id}/sse/?token=<jwt>`
+3. `POST /conversations/{id}/messages/` with user text
+4. Django's `MCPProxyClient` forwards to `http://{container_ip}:8090`
+5. Container's REST MCP API calls the AI Agent which calls the LLM
+6. LLM tokens streamed back → Redis pub/sub → Django SSE → browser
+7. Tool calls (git, bash, files) executed inside container; results returned inline
+
+---
+
+## Development Commands
+
+### Backend
+```bash
+uv sync                                      # install Python deps
+cd backend && uv run manage.py migrate       # run migrations
+uv run manage.py populate_llms               # seed LLMs
+uv run manage.py runserver                   # start Django :8000
+uv run pytest                                # run tests
+uv run ruff check . && uv run mypy .         # lint + type check
+```
+
+### Frontend
+```bash
+cd frontend && npm install
+npm run dev:django           # dev server pointed at Django
+npm run api:gen              # regenerate API client from OpenAPI spec
+npm run test:unit            # Vitest
+npm run test:integration     # Playwright
+npm run lint && npm run check
+```
+
+### Hilly Container
+```bash
+cd hilly && git submodule update --init
+./build_kasm.sh              # build hilly:latest image
+```
+
+### Full Stack (Docker Compose)
+```bash
+docker compose -f docker-compose.develop.yml up --build
+```
+
+---
+
+## Environment Variables (`.env` in project root)
+
+```bash
+DJANGO_SETTINGS_MODULE=config.settings.local
+SECRET_KEY=<django-secret>
+GITHUB_APP_ID=<id>
+GITHUB_APP_NAME=<name>
+GITHUB_APP_PRIVATE_KEY_PATH=<path-to-.pem>
+GITHUB_CLIENT_ID=<oauth-client-id>
+GITHUB_CLIENT_SECRET=<oauth-client-secret>
+ANTHROPIC_API_KEY=<key>       # optional – can be set per-user in UI
+OPENAI_API_KEY=<key>          # optional
+STRIPE_SECRET_KEY=<key>       # optional
+```
+
+---
+
+## Code Conventions
+
+- **Python**: PEP 8, 120-char line limit, type hints required, ruff + mypy enforced
+- **TypeScript/Svelte**: strict mode, `$store` reactive syntax, TailwindCSS for styles
+- **Git commits**: conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`)
+- **Modules**: keep under 300 lines; split via inheritance/composition
+- **Tests**: pytest (backend), Vitest + Playwright (frontend), Factory Boy for fixtures
+
+---
+
+## Common Tasks for an LLM Agent
+
+| Task | Where to look |
+|---|---|
+| Add a new API endpoint | `backend/holly/holly/api/views/` + register in `api/router.py` |
+| Add a new Django model | `backend/holly/holly/models/` + create migration |
+| Change mission states | `mission.py` `State` enum + `mission_service.py` |
+| Add a new Svelte route | `frontend/src/routes/<name>/+page.svelte` |
+| Add a new Svelte store | `frontend/src/lib/store/<domain>/` |
+| Modify chat SSE events | `api/views/conversations.py` + `SSEChat.svelte` |
+| Change container env vars | `container_orchestrator.py` |
+| Add an MCP tool | `hilly/aiagents/` + register in `models/tools.py` |

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -1,0 +1,376 @@
+---
+title: Holly – Backend Reference
+scope: django, models, services, api, auth, celery, containers
+audience: llm, developer
+---
+
+# Holly – Backend Reference
+
+The backend is a Django 5 project in `backend/`. It exposes a REST API via **Django Ninja**, manages mission/container lifecycle, proxies MCP calls to Hilly containers, and handles GitHub OAuth and Stripe payments.
+
+---
+
+## Django App Map
+
+```
+backend/
+├── config/
+│   ├── settings/
+│   │   ├── base.py        # shared settings
+│   │   ├── local.py       # dev overrides
+│   │   ├── develop.py     # docker-compose dev
+│   │   └── production.py  # prod
+│   ├── urls.py            # root URL router
+│   └── wsgi.py / asgi.py
+└── holly/
+    ├── holly/             # core app  ← missions, conversations, llms, tools
+    ├── github_ext/        # GitHub OAuth, App, repo management
+    ├── users/             # custom User model (email-based)
+    ├── payments/          # Stripe subscriptions
+    ├── analytics/         # usage tracking
+    ├── home/              # repository analysis / diagramming
+    └── search_app/        # cross-entity search
+```
+
+---
+
+## Models
+
+### Mission (`holly/holly/models/mission.py`)
+
+The central entity. UUID primary key.
+
+```
+Mission
+├── id          UUID (PK)
+├── title       CharField
+├── description TextField
+├── state       TextChoices → DRAFT | PROVISIONING | READY |
+│                             IN_PROGRESS | COMPLETED | ABORTED | ERROR
+├── owner       FK → User
+├── collaborators  M2M → User
+├── branch_name CharField  (shared across all repos)
+├── repositories   M2M → MissionRepos
+├── llm         FK → LLM
+├── tools       M2M → Tools
+├── knowledge_items M2M → Knowledge
+├── container_id          CharField (Docker container ID)
+├── container_ip_address  CharField
+├── container_status      CharField (starting|ready|error|stopped)
+├── container_started_at  DateTimeField
+├── init_job_id           CharField (async bootstrap job)
+├── active_jobs           JSONField
+└── requirements          JSONField
+```
+
+**MissionRepos** – pivot between Mission and RepositoryDetail, also stores `branch_name`.
+
+Key methods:
+- `can_be_accessed_by(user)` – async permission check
+- `is_container_ready()` – polls `GET /api/health` on container
+- `get_tools()` – merges all tool configs into one dict
+- `get_container_url(user)` – calls `mission_service.ensure_mission_container()`
+
+### Conversation & Message (`holly/holly/models/conversations.py`, `mission_conversation.py`)
+
+```
+MissionConversation
+├── mission     FK → Mission
+└── conversation FK → Conversation
+
+Conversation
+└── id  UUID
+
+Message
+├── conversation  FK → Conversation
+├── role          TextChoices → user | assistant | system | tool
+├── content       TextField
+├── tool_calls    JSONField
+└── created_at    DateTimeField
+```
+
+### LLM (`holly/holly/models/llms.py`)
+
+```
+LLM
+├── name        CharField
+├── provider    TextChoices → openai | anthropic | google | local
+├── model_id    CharField  (e.g. "claude-opus-4-6")
+├── is_system   BooleanField  (pre-seeded vs user-defined)
+├── api_key     encrypted field (optional – overridden by UserLLMApiKey)
+└── config      JSONField  (extra params, temperature etc.)
+```
+
+`UserLLMApiKey` stores per-user API keys linked to a provider.
+
+### Tools (`holly/holly/models/tools.py`)
+
+```
+Tools
+├── name    CharField
+├── config  JSONField  (MCP server config merged into agent tool list)
+└── is_system BooleanField
+```
+
+### Knowledge (`holly/holly/models/knowledge.py`)
+
+```
+Knowledge
+├── title   CharField
+├── content TextField  (injected into LLM system prompt)
+└── owner   FK → User
+```
+
+### GitHub models (`holly/github_ext/models.py`)
+
+```
+RepositoryDetail
+├── repo_name   CharField
+├── owner       CharField
+├── github_url  URLField
+└── installation FK → GitHubAppInstallation
+
+GitHubAppInstallation
+├── installation_id  IntegerField
+├── account_login    CharField
+└── user  FK → User
+```
+
+---
+
+## Services
+
+### MissionService (`holly/holly/services/mission_service.py`)
+
+Singleton `mission_service`. All mission lifecycle operations.
+
+```python
+mission_service.create_mission(user, data)     # → Mission (DRAFT)
+mission_service.start_mission(mission)         # DRAFT → PROVISIONING
+mission_service.stop_mission(mission)          # any → ABORTED
+mission_service.ensure_mission_container(id, user)  # idempotent start
+```
+
+### ContainerOrchestrator / HollyContainerService
+
+```
+ContainerOrchestrator
+  └── HollyContainerService
+        ├── create_container(mission)   → docker run hilly:latest
+        ├── start_container(id)
+        ├── stop_container(id)
+        ├── get_container_ip(id)
+        └── wait_for_health(ip, port, timeout)
+```
+
+Container is created with environment variables:
+
+```
+MISSION_ID=<uuid>
+MISSION_REPOS=owner/repo:branch,...
+AUTH_TOKEN=<github_token>
+DJANGO_WEBHOOK_URL=http://host:8000/_api/holly/webhooks/container/
+```
+
+### CaddyManager (`holly/holly/services/caddy_manager.py`)
+
+Dynamically manages Caddy reverse proxy routes to expose per-container web UIs (noVNC) on dynamic subdomains.
+
+### SummaryService (`holly/holly/services/summary_service.py`)
+
+Calls an LLM to generate a `title` and `branch_name` from the mission description before the container starts.
+
+### MCPProxyClient (`holly/holly/api/proxy.py`)
+
+Forwards REST calls from Django → Hilly container REST MCP API.
+
+```python
+class MCPProxyClient:
+    base_url: str  # http://{container_ip}:8090
+
+    async def send_message(conversation_id, message, tools, llm_config)
+    async def create_conversation(mission_id)
+    async def get_conversation(conversation_id)
+    async def stream_response(conversation_id) → AsyncGenerator[SSE chunks]
+```
+
+---
+
+## API Endpoints (Django Ninja)
+
+All routes under `/_api/`. JWT required on all except auth endpoints.
+
+### Auth (`/_api/auth/`)
+
+| Method | Path | Description |
+|---|---|---|
+| POST | `/token/` | Email + password → access + refresh tokens |
+| POST | `/token/refresh/` | Rotate access token |
+| POST | `/register/` | Create account |
+| GET | `/github/` | Redirect to GitHub OAuth |
+| GET | `/github/callback/` | Handle OAuth callback, issue JWT |
+
+### Missions (`/_api/holly/missions/`)
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/` | List user's missions |
+| POST | `/` | Create mission (DRAFT) |
+| GET | `/{id}/` | Get mission detail |
+| PATCH | `/{id}/` | Update mission |
+| DELETE | `/{id}/` | Delete mission |
+| GET | `/{id}/sse/start/` | **SSE** – start container, stream boot events |
+| POST | `/{id}/stop/` | Stop container |
+| POST | `/{id}/conversation/` | Create new conversation on this mission |
+
+### Conversations (`/_api/holly/conversations/`)
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/{id}/` | Get conversation + messages |
+| GET | `/{id}/sse/` | **SSE** – subscribe to streaming response |
+| POST | `/{id}/messages/` | Send user message → proxied to container |
+| DELETE | `/{id}/` | Delete conversation |
+
+### LLMs (`/_api/holly/llms/`)
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/` | List available LLMs |
+| POST | `/` | Create custom LLM |
+| GET | `/{id}/` | LLM detail |
+| DELETE | `/{id}/` | Delete |
+| GET | `/api-keys/` | List user API keys |
+| POST | `/api-keys/` | Store API key for provider |
+
+### GitHub (`/_api/github/`)
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/status/` | Connection status |
+| GET | `/installations/` | App installations |
+| GET | `/repositories/` | Repos accessible via app |
+| POST | `/webhooks/` | Receive GitHub webhooks |
+
+### Webhooks (`/_api/holly/webhooks/`)
+
+| Method | Path | Description |
+|---|---|---|
+| POST | `/container/` | Hilly container status callbacks |
+
+---
+
+## Authentication Flow (JWT + GitHub OAuth)
+
+```
+Browser                     Django                      GitHub
+  │                            │                            │
+  │──POST /auth/token/─────────▶│                            │
+  │   {email, password}        │ validate → issue JWT       │
+  │◀──{access, refresh}────────│                            │
+  │                            │                            │
+  │── GET /auth/github/ ───────▶│                            │
+  │◀──302 redirect─────────────│──────────────────────────▶│
+  │                            │                            │ user approves
+  │                            │◀── callback + code ───────│
+  │                            │ exchange code for token    │
+  │                            │ create/link SocialAccount  │
+  │◀── 302 /dashboard #token ──│                            │
+```
+
+JWT tokens:
+- Access token: short-lived (default 5 min)
+- Refresh token: long-lived (default 7 days)
+- Stored in frontend via `js-cookie`
+- SSE endpoints accept token as query param `?token=<jwt>` (EventSource doesn't support headers)
+
+---
+
+## SSE Streaming Pattern
+
+Mission start and conversation reply both use the same pattern:
+
+```python
+# backend/holly/holly/api/views/mission.py (simplified)
+@router.get("/{id}/sse/start/", auth=None)
+async def start_mission_sse(request, id: UUID, token: str):
+    user = await validate_jwt_token(token)
+    mission = await get_mission(id, user)
+
+    async def event_stream():
+        # 1. publish events to Redis channel
+        await mission_service.start_mission(mission)
+        # 2. subscribe and yield to client
+        async for event in redis.subscribe(f"mission:{id}:events"):
+            yield f"data: {event}\n\n"
+
+    return StreamingHttpResponse(event_stream(), content_type="text/event-stream")
+```
+
+Redis channel naming:
+- Mission events: `mission:{uuid}:events`
+- Conversation streaming: `conversation:{uuid}:stream`
+
+---
+
+## Background Tasks (Celery)
+
+Celery workers connect to RabbitMQ. Key tasks:
+
+| Task | Trigger |
+|---|---|
+| `clone_repository` | Mission start – clone each repo into container |
+| `generate_mission_title` | Post-creation – LLM summary |
+| `cleanup_stopped_containers` | Scheduled – remove stale containers |
+| `process_github_webhook` | GitHub webhook received |
+
+---
+
+## Settings Reference
+
+Key settings in `config/settings/base.py`:
+
+```python
+REST_MCP_SERVER_PORT = 8090       # port inside Hilly container
+AI_AGENT_PORT = 8181              # AI agent port in container
+HILLY_IMAGE = "hilly:latest"      # Docker image name
+HILLY_NETWORK = "holly_network"   # Docker network
+CADDY_API_URL = "http://caddy:2019"
+
+# JWT
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=5),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
+}
+```
+
+---
+
+## Management Commands
+
+```bash
+uv run manage.py populate_llms      # seed default LLM configurations
+uv run manage.py populate_tools     # seed default MCP tool configurations
+uv run manage.py populate_knowledge # seed example knowledge entries
+uv run manage.py createsuperuser    # create admin account
+```
+
+---
+
+## Key File Index
+
+| File | Purpose |
+|---|---|
+| `config/settings/base.py` | All shared Django settings |
+| `config/urls.py` | Root URL router, mounts Ninja API |
+| `holly/holly/models/mission.py` | Mission + MissionRepos models |
+| `holly/holly/models/conversations.py` | Message model |
+| `holly/holly/models/llms.py` | LLM configuration model |
+| `holly/holly/api/views/mission.py` | Mission CRUD + SSE start |
+| `holly/holly/api/views/conversations.py` | Chat + SSE streaming |
+| `holly/holly/api/proxy.py` | MCPProxyClient |
+| `holly/holly/services/mission_service.py` | Mission lifecycle |
+| `holly/holly/services/containers/holly_container_service.py` | Docker management |
+| `holly/holly/services/caddy_manager.py` | Reverse proxy routes |
+| `holly/github_ext/models.py` | GitHub App + repo models |
+| `holly/users/models.py` | Custom User model |

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -1,0 +1,287 @@
+---
+title: Holly – Key Data Flows
+scope: auth, mission-lifecycle, chat, tool-execution, sse, github-oauth
+audience: llm, developer
+---
+
+# Holly – Key Data Flows
+
+This document traces the critical paths through the system: authentication, mission creation and start, the chat/SSE cycle, and tool execution inside the Hilly container.
+
+---
+
+## 1. Authentication Flow
+
+### 1a. Email / Password Login
+
+```
+Browser (Svelte)             Django                    DB
+     │                          │                       │
+     │─POST /auth/token/────────▶│                       │
+     │  {email, password}       │─SELECT User──────────▶│
+     │                          │◀─User─────────────────│
+     │                          │ bcrypt verify          │
+     │                          │ sign JWT (access+refresh)
+     │◀─{access, refresh}───────│                       │
+     │  store in js-cookie      │                       │
+     │                          │                       │
+     │  [subsequent requests]   │                       │
+     │─GET /missions/───────────▶│                       │
+     │  Authorization: Bearer   │ JWTAuth.authenticate() │
+     │  <access>                │                       │
+```
+
+### 1b. GitHub OAuth Login
+
+```
+Browser          Django          GitHub          DB
+  │                 │               │              │
+  │─GET /auth/─────▶│               │              │
+  │  github/        │──302 redirect─▶│              │
+  │◀────────────────│  to github.com │              │
+  │                                 │              │
+  │  user approves OAuth app        │              │
+  │◀────302 /auth/github/callback?──│              │
+  │       code=<code>&state=...     │              │
+  │─GET callback────▶│              │              │
+  │                  │─POST oauth/─▶│              │
+  │                  │   token      │              │
+  │                  │◀─access_tok──│              │
+  │                  │ create/link SocialAccount ──▶│
+  │                  │ issue Holly JWT              │
+  │◀─302 /dashboard──│              │              │
+  │  #access=<jwt>   │              │              │
+  │  store tokens    │              │              │
+```
+
+### 1c. JWT Refresh (automatic, via middleware)
+
+```
+Browser (API middleware)      Django
+  │                              │
+  │─GET /some/endpoint/──────────▶│  ← access token expired
+  │◀─401 Unauthorized────────────│
+  │                              │
+  │─POST /auth/token/refresh/────▶│
+  │  {refresh: <refresh_token>}  │
+  │◀─{access: <new_access>}──────│
+  │  update tokens store         │
+  │                              │
+  │─GET /some/endpoint/ (retry)──▶│  ← new access token
+  │◀─200 OK──────────────────────│
+```
+
+---
+
+## 2. Mission Creation Flow
+
+### 2a. Wizard → Mission Record
+
+```
+Browser                           Django
+  │                                  │
+  │  [Wizard step 6 – submit]        │
+  │─POST /_api/holly/missions/───────▶│
+  │  {description, repos, llm_id,    │
+  │   tools, knowledge, branch_name} │
+  │                                  │ MissionService.create_mission()
+  │                                  │ ├─ LLM.generate_title_and_branch()
+  │                                  │ ├─ Mission.save(state=DRAFT)
+  │                                  │ ├─ MissionRepos.bulk_create()
+  │                                  │ └─ link tools, knowledge
+  │◀─201 {id, title, branch_name}────│
+  │  navigate to /sse-chat?mission=id │
+```
+
+---
+
+## 3. Mission Start Flow (SSE)
+
+The start endpoint is a long-lived SSE stream. The client listens until the container is READY.
+
+```
+Browser                 Django                    Docker / Hilly
+  │                       │                            │
+  │─GET /missions/{id}/   │                            │
+  │    sse/start/         │                            │
+  │    ?token=<jwt>───────▶│                            │
+  │                       │ validate JWT from query    │
+  │                       │ state → PROVISIONING       │
+  │                       │─docker run hilly:latest────▶│
+  │                       │   -e MISSION_ID=<id>        │
+  │                       │   -e MISSION_REPOS=...      │
+  │                       │   -e AUTH_TOKEN=<gh_token>  │
+  │                       │   -e DJANGO_WEBHOOK_URL=... │
+  │◀─data: container_starting│                          │
+  │                       │                            │ supervisord starts
+  │                       │                            │ REST MCP :8090
+  │                       │                            │ AI Agent :8181
+  │                       │                            │ VNC :6080
+  │                       │                            │ bootstrap script:
+  │                       │                            │   git clone repos
+  │                       │◀─POST /webhooks/container/─│
+  │                       │   {status: "ready",        │
+  │                       │    mission_id: <id>}       │
+  │                       │ Mission.state = READY      │
+  │◀─data: container_ready│                            │
+  │  EventSource.close()  │                            │
+```
+
+### SSE Event Schema
+
+```json
+{ "type": "container_starting", "data": { "container_id": "abc123" } }
+{ "type": "repo_cloning",       "data": { "repo": "owner/name" } }
+{ "type": "repo_cloned",        "data": { "repo": "owner/name" } }
+{ "type": "container_ready",    "data": { "ip": "172.17.0.5" } }
+{ "type": "error",              "data": { "message": "..." } }
+```
+
+---
+
+## 4. Chat Cycle (Conversation + SSE Streaming)
+
+```
+Browser (SSEChat)         Django (Ninja)         MCPProxy        Hilly Container
+  │                           │                      │                 │
+  │─POST /missions/{id}/      │                      │                 │
+  │    conversation/──────────▶│                      │                 │
+  │◀─{conversation_id}────────│                      │                 │
+  │                           │                      │                 │
+  │─GET /conversations/{cid}/ │                      │                 │
+  │    sse/?token=<jwt>────────▶│                      │                 │
+  │  [EventSource open]       │─subscribe Redis──────────────────────────
+  │                           │  channel             │                 │
+  │                           │                      │                 │
+  │─POST /conversations/{cid}/│                      │                 │
+  │    messages/──────────────▶│                      │                 │
+  │  {role:"user",            │ save Message         │                 │
+  │   content:"..."}          │                      │                 │
+  │                           │─MCPProxyClient.send──▶│                 │
+  │                           │                      │─POST /api/conv/─▶│
+  │                           │                      │  {message,llm,  │
+  │                           │                      │   tools}        │
+  │                           │                      │                 │ LLM API call
+  │                           │                      │                 │ stream tokens
+  │                           │                      │◀─token chunks───│
+  │                           │ publish Redis events │                 │
+  │◀─data:{type:"token",...}──│                      │                 │
+  │◀─data:{type:"token",...}──│                      │                 │
+  │  [append to message]      │                      │                 │
+  │                           │                      │◀─message_done───│
+  │◀─data:{type:"message_complete"}                  │                 │
+  │  save to DB               │                      │                 │
+```
+
+---
+
+## 5. Tool Execution Cycle (MCP)
+
+When the LLM decides to call a tool (e.g., run a shell command, git commit):
+
+```
+LLM (inside Hilly)       AI Agent :8181       REST MCP :8090      Host / GitHub
+  │                           │                     │                   │
+  │─tool_call: git_commit─────▶│                     │                   │
+  │   {message: "feat: ..."}  │                     │                   │
+  │                           │─POST /api/git/      │                   │
+  │                           │    commit/──────────▶│                   │
+  │                           │                     │ git commit -m ...  │
+  │                           │                     │─git push origin───▶│
+  │                           │                     │◀─push ok──────────│
+  │                           │◀─{status:"ok",      │                   │
+  │                           │   sha:"abc123"}──────│                   │
+  │◀─tool_result──────────────│                     │                   │
+  │   {sha: "abc123"}         │                     │                   │
+  │                           │                     │                   │
+  │  [continue generation]    │                     │                   │
+```
+
+The Django backend is also a proxy path for tool calls that come from conversations:
+
+```
+Django /conversations/{id}/messages/
+  └─ MCPProxyClient.send_message()
+       └─ POST http://{container_ip}:8090/api/conversations/{cid}/messages/
+            └─ REST MCP forwards to AI Agent :8181
+                 └─ AI Agent calls LLM API
+                      └─ LLM emits tool_calls
+                           └─ MCP server executes locally (git/shell/files)
+```
+
+### Tool Call SSE Events (visible in frontend)
+
+```
+data: {"type":"tool_call",  "name":"bash",   "args":{"cmd":"pytest -x"}}
+data: {"type":"token",      "content":"Running tests...\n"}
+data: {"type":"tool_result","name":"bash",   "output":"5 passed","exit_code":0}
+data: {"type":"token",      "content":"All tests pass. "}
+data: {"type":"message_complete"}
+```
+
+---
+
+## 6. GitHub App Installation Flow
+
+After OAuth login the user must install the Holly GitHub App on their repos before creating a mission.
+
+```
+Browser                Django              GitHub App        GitHub API
+  │                       │                    │                 │
+  │─GET /github/status/───▶│                    │                 │
+  │◀─{installed: false}───│                    │                 │
+  │                       │                    │                 │
+  │  [click Install App]  │                    │                 │
+  │─redirect to────────────────────────────────▶│                 │
+  │  github.com/apps/holly-app/installations   │                 │
+  │                       │                    │ user selects repos
+  │◀─callback to ─────────────────────────────│                 │
+  │  /github/callback?    │                    │                 │
+  │  installation_id=<n>  │                    │                 │
+  │                       │ save GitHubAppInstallation          │
+  │                       │─GET /installations/{n}/repos────────▶│
+  │                       │◀─repo list──────────────────────────│
+  │                       │ save RepositoryDetail records        │
+  │◀─redirect /dashboard──│                    │                 │
+```
+
+---
+
+## 7. Mission Stop / Teardown
+
+```
+Browser            Django                  Docker
+  │                   │                       │
+  │─POST /missions/   │                       │
+  │    {id}/stop/─────▶│                       │
+  │                   │ mission.state=ABORTED  │
+  │                   │─docker stop <cid>─────▶│
+  │                   │─docker rm <cid>────────▶│
+  │                   │ CaddyManager.remove_route(id)
+  │◀─200 {state:"aborted"}                    │
+```
+
+---
+
+## Redis Channel Reference
+
+| Channel | Publisher | Subscriber | Events |
+|---|---|---|---|
+| `mission:{uuid}:events` | Django (mission_service) | Django SSE handler | container_starting, repo_cloning, container_ready, error |
+| `conversation:{uuid}:stream` | MCPProxyClient | Django SSE handler | token, tool_call, tool_result, message_complete |
+
+---
+
+## Port Reference
+
+| Service | Port | Notes |
+|---|---|---|
+| Django dev server | 8000 | REST API + admin |
+| SvelteKit dev | 5173 | Vite HMR |
+| Caddy | 80 / 443 | reverse proxy |
+| Redis | 6379 | pub/sub + cache |
+| RabbitMQ | 5672 | Celery broker |
+| Hilly REST MCP | 8090 | per-container |
+| Hilly AI Agent | 8181 | per-container |
+| Hilly noVNC | 6080 | per-container |
+| Hilly VNC | 5901 | per-container |

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,0 +1,291 @@
+---
+title: Holly – Frontend Reference
+scope: sveltekit, routes, stores, components, api-client, sse
+audience: llm, developer
+---
+
+# Holly – Frontend Reference
+
+The frontend is a **SvelteKit 2 + TypeScript** application in `frontend/`. It uses TailwindCSS + Flowbite for UI, auto-generated API clients for the Django backend, and EventSource (SSE) for real-time streaming.
+
+---
+
+## Directory Structure
+
+```
+frontend/src/
+├── routes/                    # SvelteKit file-based routing
+│   ├── (auth)/                # layout group – redirects if not authed
+│   │   ├── login/
+│   │   ├── register/
+│   │   └── forgot-password/
+│   ├── dashboard/             # home page after login
+│   ├── wizard/                # 6-step mission creation
+│   ├── sse-chat/              # real-time chat with LLM
+│   ├── github/
+│   │   ├── connect/           # OAuth connect flow
+│   │   └── account/           # manage installations
+│   ├── llms/                  # LLM management
+│   └── settings/              # user profile + API keys
+└── lib/
+    ├── apis/                  # API wrapper functions
+    │   ├── api.config.ts      # base URL + auth headers (reactive)
+    │   ├── mission/           # mission API calls
+    │   ├── conversation/      # chat API calls
+    │   ├── github/            # github API calls
+    │   ├── llm/               # llm API calls
+    │   └── middleware/        # token-refresh interceptor
+    ├── store/                 # Svelte writable stores
+    │   ├── auth/              # tokens, user identity
+    │   ├── mission/           # selected mission
+    │   ├── chat/              # active conversation + messages
+    │   └── wizard.store.ts    # wizard multi-step state
+    ├── components/            # reusable UI components
+    └── utils/                 # helpers (logger, formatters)
+```
+
+---
+
+## Routes
+
+### `(auth)/login` – Login Page
+
+**File:** `src/routes/(auth)/login/+page.svelte`
+
+Email + password form. On success stores JWT tokens via `tokens.store.ts` and navigates to `/dashboard`. Includes "remember me" (persists refresh token to cookie).
+
+### `(auth)/register` – Registration
+
+**File:** `src/routes/(auth)/register/+page.svelte`
+
+Creates a new account via `POST /_api/auth/register/`. Auto-logs in on success.
+
+### `dashboard` – Dashboard
+
+**File:** `src/routes/dashboard/+page.svelte`
+
+Shows summary stats (missions, repos, conversations). Quick-launch buttons for wizard and chat. Fetches data on mount using `loadDashboard()`.
+
+### `wizard` – Mission Creation Wizard
+
+**File:** `src/routes/wizard/+page.svelte`
+
+Multi-step wizard backed by `wizard.store.ts`.
+
+```
+Step 1: Branch name (auto-suggested by LLM on description entry)
+Step 2: Select repositories (from GitHub installations)
+Step 3: Choose LLM model
+Step 4: Select tools (MCP servers)
+Step 5: Select knowledge base items
+Step 6: Mission description + confirm
+```
+
+On submit: `POST /_api/holly/missions/` → navigates to `/sse-chat?mission=<id>`.
+
+### `sse-chat` – Real-Time Chat Interface
+
+**File:** `src/routes/sse-chat/+page.svelte`
+**Component:** `src/lib/components/chat/SSEChat.svelte`
+
+The main interaction surface. Opens an `EventSource` for streaming. See [flows.md](flows.md) for the full chat cycle.
+
+Key responsibilities:
+- Create or resume a `MissionConversation`
+- Subscribe to SSE stream on `/_api/holly/conversations/{id}/sse/`
+- Send user messages via `POST /_api/holly/conversations/{id}/messages/`
+- Render streaming tokens as they arrive
+- Display tool calls and results inline
+
+### `github/connect` – GitHub OAuth Connect
+
+**File:** `src/routes/github/connect/+page.svelte`
+
+Initiates GitHub OAuth redirect via `GET /_api/auth/github/`. On return from callback, links the GitHub account and prompts user to install the GitHub App on their repos.
+
+### `llms` – LLM Management
+
+**File:** `src/routes/llms/+page.svelte`
+
+Lists system LLMs and allows adding custom ones with personal API keys. CRUD for `UserLLMApiKey`.
+
+---
+
+## Svelte Stores
+
+Stores are in `src/lib/store/`. All are `writable` (or derived). Persistent stores use `js-cookie` for cross-session auth.
+
+### `auth/tokens.store.ts`
+
+```typescript
+tokens: {
+  access: string | null
+  refresh: string | null
+}
+isAuthenticated: boolean  // derived
+currentUser: User | null
+```
+
+`isAuthenticated` is read in `+layout.svelte` to guard protected routes. Token refresh is handled transparently in the API middleware.
+
+### `mission/mission.store.ts`
+
+```typescript
+selectedMission: Mission | null
+missions: Mission[]
+```
+
+Set when the user opens the wizard or navigates to a mission. Used by `sse-chat` to know which mission to attach conversations to.
+
+### `chat/chat.store.ts`
+
+```typescript
+activeConversation: Conversation | null
+messages: Message[]
+isStreaming: boolean
+```
+
+Updated by the SSE event handler in `SSEChat.svelte`.
+
+### `wizard.store.ts`
+
+```typescript
+currentStep: number  (1–6)
+branchName: string
+selectedRepos: RepositoryDetail[]
+selectedLLM: LLM | null
+selectedTools: Tools[]
+selectedKnowledge: Knowledge[]
+description: string
+```
+
+Cleared on wizard completion or cancel.
+
+---
+
+## API Client
+
+### Auto-generation
+
+```bash
+cd frontend
+npm run api:gen          # generate TS client from backend OpenAPI spec
+npm run api:full         # generate + sync (requires Django to be running)
+```
+
+Generated files live in `frontend/gen/openapi/`. Do not edit by hand.
+
+### API Config (`src/lib/apis/api.config.ts`)
+
+Provides a reactive configuration object that injects the current `Authorization: Bearer <token>` header on every request, and hooks into the token-refresh middleware.
+
+```typescript
+export const apiConfig = derived(tokens, ($tokens) => ({
+  baseUrl: API_BASE_URL,
+  headers: $tokens.access
+    ? { Authorization: `Bearer ${$tokens.access}` }
+    : {}
+}))
+```
+
+### Mission API (`src/lib/apis/mission/api.mission.ts`)
+
+```typescript
+createMission(data: MissionCreate): Promise<Mission>
+getMission(id: string): Promise<Mission>
+listMissions(): Promise<Mission[]>
+deleteMission(id: string): Promise<void>
+createConversation(missionId: string): Promise<Conversation>
+```
+
+### Conversation API (`src/lib/apis/conversation/api.conversation.ts`)
+
+```typescript
+sendMessage(conversationId: string, content: string): Promise<void>
+getConversation(id: string): Promise<Conversation>
+openSSEStream(conversationId: string, token: string): EventSource
+```
+
+### Token Refresh Middleware (`src/lib/apis/middleware/token-refresh.middleware.ts`)
+
+Wraps every fetch. On HTTP 401:
+1. Calls `POST /auth/token/refresh/` with stored refresh token
+2. Stores new access token
+3. Retries the original request once
+4. If refresh also fails → clears tokens → redirects to `/login`
+
+---
+
+## Key Components
+
+### `SSEChat.svelte`
+
+Core chat UI. Maintains an `EventSource` for streaming. Parses SSE event types:
+
+| Event type | Action |
+|---|---|
+| `token` | Append to current assistant message bubble |
+| `message_complete` | Finalise message, re-enable input |
+| `tool_call` | Show tool call card (name + args) |
+| `tool_result` | Update tool call card with result |
+| `error` | Show error toast, re-enable input |
+| `mission_status` | Update mission state badge |
+
+### `MissionCard.svelte`
+
+Summary card on dashboard. Shows title, state badge, repo names, last activity.
+
+### `WizardStep.svelte`
+
+Wraps each wizard step with back/next navigation and validation guard.
+
+### `LLMSelector.svelte`
+
+Dropdown with LLM name, provider badge, and model ID. Reflects `selectedLLM` store.
+
+---
+
+## Environment Variables
+
+`frontend/.env` (copy from `frontend/env.example`):
+
+```bash
+PUBLIC_API_BASE_URL=http://localhost:8000   # Django backend URL
+PUBLIC_GITHUB_CONNECT_URL=/api/auth/github/ # OAuth entry point
+```
+
+---
+
+## Build & Dev Scripts
+
+```bash
+npm run dev           # Vite dev server :5173 (standalone)
+npm run dev:django    # dev server pointed at local Django
+npm run build         # production build → dist/
+npm run preview       # preview production build locally
+npm run test:unit     # Vitest unit tests
+npm run test:integration  # Playwright E2E
+npm run lint          # ESLint + Svelte check
+npm run format        # Prettier
+npm run check         # svelte-check type validation
+npm run api:gen       # regenerate API client
+```
+
+---
+
+## Key File Index
+
+| File | Purpose |
+|---|---|
+| `src/routes/(auth)/login/+page.svelte` | Login form + JWT storage |
+| `src/routes/wizard/+page.svelte` | Mission creation wizard |
+| `src/routes/sse-chat/+page.svelte` | Chat page shell |
+| `src/lib/components/chat/SSEChat.svelte` | Streaming chat UI |
+| `src/lib/store/auth/tokens.store.ts` | JWT token state |
+| `src/lib/store/mission/mission.store.ts` | Selected mission state |
+| `src/lib/store/chat/chat.store.ts` | Conversation + messages |
+| `src/lib/store/wizard.store.ts` | Wizard multi-step state |
+| `src/lib/apis/api.config.ts` | Auth header injection |
+| `src/lib/apis/mission/api.mission.ts` | Mission API calls |
+| `src/lib/apis/conversation/api.conversation.ts` | Chat API calls |
+| `src/lib/apis/middleware/token-refresh.middleware.ts` | Auto JWT refresh |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,195 @@
+---
+title: Holly – System Overview
+scope: architecture, concepts, stack, deployment
+audience: llm, developer
+---
+
+# Holly – System Overview
+
+Holly is an AI-assisted software development workspace. Engineers hand off scoped coding **missions** to LLMs. Each mission runs inside an isolated Docker container (**Hilly**) where the model can clone repositories, edit code, run tests, and push changes – all without touching the host machine.
+
+The UI streams real-time progress back via Server-Sent Events (SSE). Any frontier or local LLM can be used, and the container image can be swapped for a hardened alternative.
+
+> **Security warning:** The default Hilly image runs with `privileged: true` to support VNC. Do not expose this on a publicly accessible host without hardening the container.
+
+---
+
+## High-Level Architecture
+
+```mermaid
+graph TB
+    User["User (browser)"]
+
+    subgraph "Frontend – SvelteKit :5173"
+        FE[Pages / Wizard / Chat]
+        STORES[Svelte Stores]
+        API_CLIENT[Auto-gen API Client]
+    end
+
+    subgraph "Backend – Django :8000"
+        NINJA[Django Ninja REST API]
+        AUTH[JWT Auth]
+        SERVICES[Mission / Container Services]
+        DB[(SQLite / PostgreSQL)]
+        REDIS[(Redis)]
+        CELERY[Celery Worker]
+    end
+
+    subgraph "Hilly Container (per mission)"
+        REST_MCP[REST MCP API :8090]
+        AI_AGENT[AI Agent API :8181]
+        VNC[KasmVNC :6080]
+        GIT[Git Operations]
+    end
+
+    subgraph "External"
+        GITHUB[GitHub API]
+        LLM_CLOUD[LLM Providers\nClaude / GPT / Gemini]
+        STRIPE[Stripe]
+    end
+
+    User --> FE
+    FE --> STORES --> API_CLIENT
+    API_CLIENT -->|REST + SSE| NINJA
+    NINJA --> AUTH
+    NINJA --> SERVICES
+    SERVICES --> DB
+    SERVICES --> REDIS
+    SERVICES --> CELERY
+    SERVICES -->|Docker SDK| Hilly Container
+    REST_MCP --> GIT --> GITHUB
+    AI_AGENT --> LLM_CLOUD
+    NINJA -->|proxy MCP calls| REST_MCP
+    NINJA --> GITHUB
+    NINJA --> STRIPE
+```
+
+---
+
+## ASCII Deployment View
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Host Machine                                               │
+│                                                             │
+│  ┌──────────────┐   ┌───────────────────────────────────┐  │
+│  │  Caddy :80   │   │  Django :8000  +  SvelteKit :5173 │  │
+│  │  Reverse     │──▶│  Redis  :6379  +  RabbitMQ :5672  │  │
+│  │  Proxy       │   └──────────────────┬────────────────┘  │
+│  └──────────────┘                      │ Docker SDK         │
+│                                        ▼                    │
+│                          ┌────────────────────────┐         │
+│                          │  Hilly Container        │         │
+│                          │  (per mission)          │         │
+│                          │  :8090 REST MCP         │         │
+│                          │  :8181 AI Agent         │         │
+│                          │  :6080 noVNC            │         │
+│                          └────────────────────────┘         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Core Concepts
+
+| Concept | Description |
+|---|---|
+| **Mission** | A scoped coding task (feature, bugfix, refactor). Has state, repos, LLM, tools, knowledge. |
+| **Hilly** | Per-mission Docker container. Ubuntu + Xfce + VNC + REST API + AI agent. |
+| **MCP (Model Context Protocol)** | Protocol used by the AI agent inside Hilly to invoke tools (git, shell, file ops). |
+| **MCP Proxy** | Django's `MCPProxyClient` forwards tool calls from the LLM to the running container. |
+| **SSE** | Server-Sent Events used for real-time streaming (mission boot progress, chat tokens). |
+| **Conversation** | A chat thread linked to a mission. Many conversations per mission are allowed. |
+| **Knowledge** | User-defined context snippets fed to the LLM system prompt. |
+| **Tools** | MCP server configurations (git, shell, file system) made available per mission. |
+
+---
+
+## Mission Lifecycle
+
+```
+DRAFT
+  │  wizard complete, POST /missions/
+  ▼
+PROVISIONING
+  │  Docker container starting, repos cloning
+  ▼
+READY
+  │  container healthy, repos on disk
+  ▼
+IN_PROGRESS
+  │  user chatting, LLM writing code
+  ▼
+COMPLETED ─── or ─── ABORTED ─── or ─── ERROR
+```
+
+---
+
+## Technology Stack
+
+### Backend
+| Layer | Technology |
+|---|---|
+| Web framework | Django 5.1.5 |
+| REST API | Django Ninja (OpenAPI auto-docs) |
+| Authentication | django-allauth + simplejwt |
+| Background tasks | Celery + RabbitMQ |
+| Cache / pub-sub | Redis |
+| Container mgmt | Docker SDK for Python |
+| Reverse proxy | Caddy |
+| DB | SQLite (dev) / PostgreSQL (prod) |
+| HTTP client (async) | httpx |
+| Payments | Stripe |
+
+### Frontend
+| Layer | Technology |
+|---|---|
+| Framework | SvelteKit 2 + TypeScript |
+| Styling | TailwindCSS + Flowbite |
+| API client | Auto-generated from OpenAPI spec |
+| Real-time | EventSource (SSE) |
+| Unit tests | Vitest |
+| E2E tests | Playwright |
+| Build | Vite |
+
+### Hilly Container
+| Layer | Technology |
+|---|---|
+| Base image | Ubuntu 22.04 + KasmVNC |
+| REST API | FastAPI (port 8090) |
+| AI Agent | Custom agent + MCP tools (port 8181) |
+| Runtime | Python 3.11 (uv), Node.js, Git |
+
+---
+
+## Repository Layout
+
+```
+holly/
+├── backend/              # Django project
+│   ├── config/           #   settings, URLs, WSGI
+│   └── holly/            #   Django apps
+│       ├── holly/        #     missions, conversations, LLMs, tools
+│       ├── github_ext/   #     GitHub OAuth & app integration
+│       ├── users/        #     custom User model
+│       └── payments/     #     Stripe subscriptions
+├── frontend/             # SvelteKit app
+│   └── src/
+│       ├── routes/       #   pages
+│       └── lib/          #   stores, components, API wrappers
+├── hilly/                # AI agent Docker image
+│   ├── rest_mcp_client/  #   FastAPI REST MCP server
+│   └── aiagents/         #   AI agent + MCP tooling (git submodule)
+├── docs/                 # LLM-optimised documentation (this folder)
+├── scripts/              # Setup helpers (GitHub app, secrets)
+└── tests/                # Top-level integration tests
+```
+
+---
+
+## Related Docs
+
+- [`docs/backend.md`](backend.md) – Django apps, models, services, API endpoints
+- [`docs/frontend.md`](frontend.md) – SvelteKit routes, stores, components
+- [`docs/flows.md`](flows.md) – Auth, mission start, chat, tool execution flows
+- [`docs/GH_APP_SETUP.md`](GH_APP_SETUP.md) – GitHub App configuration


### PR DESCRIPTION
Create four structured docs in docs/ with high signal-to-noise ratio for LLM agents:
- docs/overview.md  – architecture mermaid diagram, core concepts, tech stack, repo layout
- docs/backend.md   – Django models, services, API endpoints, auth, SSE pattern, settings
- docs/frontend.md  – SvelteKit routes, Svelte stores, API client, key components
- docs/flows.md     – ASCII/mermaid sequence diagrams for auth, mission start, chat cycle,
                      tool execution, GitHub OAuth, and teardown

Add CLAUDE.md at repo root with quick orientation, doc index, mission lifecycle,
common task lookup table, and dev commands for LLM agents working in this codebase.

https://claude.ai/code/session_01Uf976UGo3xUETpB38Y5gCn